### PR TITLE
[Pull Request] Fix `PluginStruct.json` name error for right behavior in `KitX Dashboard`

### DIFF
--- a/ResourcesMonitor.WPF/PluginStruct.json
+++ b/ResourcesMonitor.WPF/PluginStruct.json
@@ -1,9 +1,9 @@
 {
-  "Name": "ResourceMonitor",
+  "Name": "ResourcesMonitor",
   "Version": "v1.0.0",
   "DisplayName": {
     "zh-cn": "资源监视器",
-    "en-us": "Resource Monitor"
+    "en-us": "Resources Monitor"
   },
   "AuthorName": "StarInk",
   "PublisherName": "Crequency",
@@ -46,5 +46,5 @@
       "ReturnValueType": "void"
     }
   ],
-  "RootStartupFileName": "ResourceMonitor.dll"
+  "RootStartupFileName": "ResourcesMonitor.WPF.dll"
 }


### PR DESCRIPTION
Fixes:

- `RootStartupFileName`: `ResourceMonitor.dll` -> `ResourcesMonitor.WPF.dll`